### PR TITLE
Password field instead of plain text

### DIFF
--- a/web/plugins/wato/register-tls_cee.py
+++ b/web/plugins/wato/register-tls_cee.py
@@ -42,7 +42,7 @@ def _valuespec_agent_config_register_tls():
                     "The User should have the Privilige to Pair an Agent, Read all hosts, write all hosts "),
                 allow_empty=False
             )),
-            ("tls_password", TextAscii(
+            ("tls_password", Password(
                 title=_("Password / Secret for Registration User"),
                 allow_empty=False
             )),


### PR DESCRIPTION
Please use the Password instead of TextAscii, so that in the GUI the password isn't shown as plain text.